### PR TITLE
docs(copy): editorial pass over site copy

### DIFF
--- a/src/components/completionItem.astro
+++ b/src/components/completionItem.astro
@@ -18,7 +18,11 @@ const { name, location, acquired, id, repeatable, amount } = Astro.props;
   <div class="text-left col-span-2 p-2">
     {!!name && <div class="text-2xl">{name}</div>}
     {!!location && <div>{`Location: ${location}`}</div>}
-    {!!acquired && <div>{`Acquired by ${acquired}`}</div>}
+    {
+      /* "Source" rather than "Acquired by": the field holds people ("Dad") as
+        well as events ("After completing Escape!"), and only one label fits both. */
+    }
+    {!!acquired && <div>{`Source: ${acquired}`}</div>}
     {
       !!amount && (
         <div class="grid grid-cols-3 lg:grid-cols-5 flex-wrap gap-2 w-full">

--- a/src/data/checklistdata.json
+++ b/src/data/checklistdata.json
@@ -774,7 +774,7 @@
             "name": "Aiding the Outcasts",
             "type": "side",
             "location": "Bailey's Crossroads",
-            "acquired": "Outcast distress signal",
+            "acquired": "Outcast Distress Signal",
             "available": "",
             "wikiUrl": "",
             "repeatable": "f",

--- a/src/data/quests.csv
+++ b/src/data/quests.csv
@@ -69,7 +69,7 @@ Ryan Brigg's Wonder Meat,side,Jury St. Station,Wonder Meat Maker,,,t,main
 The Outcast Collection Agent,side,Fort Independence,Protector Casdin,,,t,main
 Water Beggars,side,Tenpenny Tower,"Willy, outside Tenpenny Tower",,,t,main
 Yearning for Learning,side,Arlington Library,Scribe Yearling,,,t,main
-Aiding the Outcasts,side,Bailey's Crossroads,Outcast distress signal,,,f,operation_anchorage
+Aiding the Outcasts,side,Bailey's Crossroads,Outcast Distress Signal,,,f,operation_anchorage
 The Guns of Anchorage,side,Anchorage Reclamation Simulation,Sgt. Benjamin Montgomery,,,f,operation_anchorage
 Paving the Way,side,Anchorage Reclamation Simulation,General Chase,,,f,operation_anchorage
 Operation: Anchorage!,side,Anchorage Reclamation Simulation,General Chase,,,f,operation_anchorage

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -2,7 +2,12 @@
 import Link from "../components/link.astro";
 import "../styles/base.css";
 
-const { showNav, baseName } = Astro.props;
+const {
+  showNav,
+  baseName,
+  title = "Fallout 3 Checklist",
+  description = "A 100%+ completionist checklist for Fallout 3: every quest, item and collectible in the Capital Wasteland, with your progress saved as you go.",
+} = Astro.props;
 
 let parsedBase = baseName;
 while (parsedBase?.startsWith("/")) {
@@ -25,6 +30,7 @@ if (parsedBase?.length > 0) {
     />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
+    <meta name="description" content={description} />
 
     <!-- Google Font -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -35,7 +41,7 @@ if (parsedBase?.length > 0) {
       as="style"
       onload="this.onload=null;this.rel='stylesheet'"
     />
-    <title>Fallout 3 Checklist</title>
+    <title>{title}</title>
 
     <script is:inline src="/fallout3-checklist/colorToggle.js"></script>
   </head>
@@ -49,10 +55,14 @@ if (parsedBase?.length > 0) {
     >
       {
         showNav && (
-          <nav>
-            <div class="pl-4 pt-4">
-              <Link href="/fallout3-checklist/" label="<--- Back to Home" />
-            </div>
+          <nav class="flex items-center justify-between gap-4 pl-4 pr-4 pt-4">
+            <Link href="/fallout3-checklist/" label="<--- Home" />
+            <button
+              id="colorButton"
+              class="border border-pip-dark text-pip-dark p-2 hover:text-pip-light hover:border-pip-light"
+            >
+              Change Theme
+            </button>
           </nav>
         )
       }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,27 +6,22 @@ const url =
   "https://www.reddit.com/r/Fallout/comments/7z843q/i_made_a_fallout_3_fullcompletion_checklist/";
 ---
 
-<Layout showNav>
+<Layout showNav title="About | Fallout 3 Checklist">
   <div
     class="mx-auto container bg-transparent flex-col justify-center text-pip-dark text-mono"
   >
-    <div class="text-6xl m-4">About</div>
+    <h1 class="text-6xl m-4">About</h1>
     <div class="">
       <h2 class="italic text-3xl">Inspiration / Recognitions</h2>
       <p class="ml-4">
-        This checklist website is inspired by a few things. First, this
-        checklist is mainly inspired by{" "}
-        <span class="italic">FALLOUT 3 WASTELAND CHECKLIST </span> by Logea, a pdf
-        checklist that was promoted on reddit in this <Link
-          href={url}
-          label="post"
-        />.
+        This checklist owes a debt to a few places. The biggest is{" "}
+        <span class="italic">FALLOUT 3 WASTELAND CHECKLIST</span> by Logea, a PDF
+        posted to Reddit in this <Link href={url} label="post" />.
       </p>
       <p class="ml-4">
-        Transitive thanks should be given as well: The format of this Fallout 3
-        checklist is based on the Mass Effect Galactic Checklists by Teryx and
-        ZimmMaster (formerly hosted at masseffect.shockfront.net). Many, many
-        thanks to them!
+        Thanks are due further up the chain, too: the format comes from the Mass
+        Effect Galactic Checklists by Teryx and ZimmMaster (formerly hosted at
+        masseffect.shockfront.net). Many, many thanks to them!
       </p>
     </div>
     <div>
@@ -34,25 +29,19 @@ const url =
       <p class="ml-4">
         All content is sourced from the Fallout Wiki, IGN’s quest guides, or the
         game itself. Fallout is the intellectual property of Bethesda Softworks
-        LLC.
+        LLC. This is an unofficial fan project and is not affiliated with or
+        endorsed by Bethesda.
       </p>
     </div>
 
     <div class="text-center mt-12">
       <p>
-        Feel free to fork and share this checklist. Github Issues and Pull
-        Requests are always welcome!
+        Feel free to fork and share this checklist. GitHub issues and pull
+        requests are always welcome!
       </p>
       <p>
-        Have fun completing the wasteland and remember... Don't feed the Yao
-        Guai!
+        Have fun completing the wasteland and remember… Don’t feed the Yao Guai!
       </p>
     </div>
-
-    <button
-      id="colorButton"
-      class="border border-pip-dark text-pip-dark p-2 hover:text-pip-light hover:border-pip-light"
-      >Toggle Color</button
-    >
   </div>
 </Layout>

--- a/src/pages/guide.astro
+++ b/src/pages/guide.astro
@@ -17,9 +17,24 @@ const agg = (acc, curr) => {
 
 const collectableKeys = data["collectables"].reduce(agg, []);
 console.log(collectableKeys);
+
+// Rendered into the scoreboard so the first paint shows the real total rather
+// than a placeholder the client script immediately overwrites. Mirrors the
+// count in updateScoreboard(): every non-ignored checkbox in the form.
+const totalCheckboxes =
+  data["quests"].reduce(
+    (n, quest) => n + 1 + (quest["repeatable"] === "f" ? 1 : 0),
+    0,
+  ) +
+  data["items"].length +
+  data["collectables"].length;
 ---
 
-<Layout showNav baseName={"guide"}>
+<Layout
+  showNav
+  baseName={"guide"}
+  title="Capital Wasteland Checklist | Fallout 3 Checklist"
+>
   <div
     class="grid place-items-center text-pip-dark text-center overflow-x-auto text-mono p-4 scroll-px-1.5 px-10"
   >
@@ -37,7 +52,7 @@ console.log(collectableKeys);
           <a class={`block ${linkStyles}`} href="guide/#quests">Quests</a>
           <a class={`block ${linkStyles}`} href="guide/#items">Items</a>
           <a class={`block ${linkStyles}`} href="guide/#collectables"
-            >Collectables</a
+            >Collectibles</a
           >
         </div>
 
@@ -47,38 +62,38 @@ console.log(collectableKeys);
           <input
             id="main-search-box"
             type="text"
-            placeholder="search here"
+            placeholder="Search the wasteland..."
             class="self-center text-3xl flex-1 flex-wrap max-w-lg bg-stone-900 h-12 px-4 rounded-lg appearance-none border border-pip-mid/20"
           />
           <button
             id="clear-search-btn"
             class="border w-fit self-center p-3 border-pip-mid w-1/4 sm:w-fit"
-            >Clear</button
+            >Clear Search</button
           >
         </div>
 
         <div class="p-2 flex flex-col justify-center order-first md:order-none">
-          <h4 class="text-2xl">Action Items</h4>
-          <h1 id="scoreboard" class="text-5xl">0/999</h1>
+          <h2 class="text-2xl">Progress</h2>
+          <p id="scoreboard" class="text-5xl">0/{totalCheckboxes}</p>
         </div>
       </div>
 
       <div>
-        <h3>Filters</h3>
+        <h2>Filters</h2>
         <div class="p-2 flex justify-between items-center">
           <Checkbox id="hide-quests-toggle" defaultChecked label="Quests" />
           <Checkbox id="hide-items-toggle" defaultChecked label="Items" />
           <Checkbox
             id="hide-collectables-toggle"
             defaultChecked
-            label="Collectables"
+            label="Collectibles"
           />
         </div>
       </div>
 
       <form id="game-form">
         <section id="quest-section">
-          <h1 id="quests" class="text-6xl m-2 underline">Quests</h1>
+          <h2 id="quests" class="text-6xl m-2 underline">Quests</h2>
           <div class="grid sm:grid-cols-2 gap-2 md:grid-cols-3 xl:grid-cols-6">
             {
               data["quests"]?.map((datum) => {
@@ -97,7 +112,7 @@ console.log(collectableKeys);
         </section>
 
         <section id="items-section">
-          <h1 id="items" class="text-6xl m-2 underline mb-8">Items</h1>
+          <h2 id="items" class="text-6xl m-2 underline mb-8">Items</h2>
 
           <h3 id="clothing" class="text-4xl m-2 italic">Clothing</h3>
           <div class="grid sm:grid-cols-2 md:grid-cols-3 gap-2 xl:grid-cols-6">
@@ -134,9 +149,9 @@ console.log(collectableKeys);
           </div>
         </section>
         <section id="collectables-section">
-          <h1 id="collectables" class="text-6xl m-2 underline mb-8">
-            Collectables
-          </h1>
+          <h2 id="collectables" class="text-6xl m-2 underline mb-8">
+            Collectibles
+          </h2>
           <section id="bobblehead-section">
             <h3 id="bobblehead-heading" class="text-4xl m-2 italic">
               Bobbleheads
@@ -330,7 +345,7 @@ console.log(collectableKeys);
         </section>
       </form>
       <div class="p-2 flex flex-col justify-center">
-        <button id="resetButton" class={buttonClazz}>Clear</button>
+        <button id="resetButton" class={buttonClazz}>Reset All Progress</button>
       </div>
     </game-checklist>
   </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,7 +14,7 @@ import Layout from "../layouts/layout.astro";
         Fallout 3 Checklist
       </h1>
       <div class="text-2xl">
-        A 100+% Completionist Guide of the Capital Wasteland
+        A 100%+ Completionist Guide to the Capital Wasteland
       </div>
       <div class="grid grid-cols-2 italic">
         <a href="about" class={linkStyles}>About</a>


### PR DESCRIPTION
An editorial pass over everything the site says. Clean single commit on top of the Astro 7 / Tailwind 4 upgrade in #9.

## The label that didn't fit its data

`completionItem.astro` hardcoded `Acquired by ${acquired}`, but that field holds two different kinds of value — people *and* events. Six cards read as broken English:

| before | after |
|---|---|
| Acquired by Dad | Source: Dad |
| Acquired by **After completing Escape!** | Source: After completing Escape! |
| Acquired by **Vault 101 Distress Signal** | Source: Vault 101 Distress Signal |
| Acquired by **Prime (via terminal)** | Source: Prime (via terminal) |

`Source:` fits every value and lines up with the `Location:` label directly above it. One-line fix, no data migration.

## Corrections

- `pdf` → `PDF`, `reddit` → `Reddit`, `Github` → `GitHub`
- Consistent typographic apostrophes — the About page had a curly `’` in "IGN’s" and a straight `'` in "Don't", one paragraph apart
- `100+%` → `100%+`, and "Guide **of** the Capital Wasteland" → "Guide **to**"
- `Outcast distress signal` → `Outcast Distress Signal`, matching `Vault 101 Distress Signal` (fixed in `quests.csv`, the source the JSON is generated from)

## Rewrites

The About opening tripped over itself — *"This **checklist** website is **inspired** by a few things. First, this **checklist** is mainly **inspired** by…"* — and opened a list with "First," that never had a second item. *"Transitive thanks should be given as well:"* used a maths word for a human sentiment. Both rewritten in plain English.

The disclaimer now states this is an unofficial fan project not affiliated with Bethesda, rather than only noting who owns Fallout.

## Voice

The best line on the site is "Have fun completing the wasteland and remember… Don't feed the Yao Guai!" — but the UI around it said **"Action Items"** over the score, which is corporate-speak on a Pip-Boy. Now "Progress". The search placeholder `search here` is now `Search the wasteland...`.

Also: **two different buttons were both labelled "Clear"** — one clears the search box, the other wipes all saved progress. Now "Clear Search" and "Reset All Progress".

`Collectables` → `Collectibles` (the spelling the Fallout Wiki uses) **in display text only**. The `id`s keep the old spelling deliberately — they're localStorage keys, and renaming them would wipe every existing user's saved progress.

## Structure

- **Per-page `<title>`s.** All three pages shared `Fallout 3 Checklist`, so bookmarking two of them gave identical entries. Plus a meta description.
- **One `<h1>` per page.** About's title was a `<div class="text-6xl">`; the guide had five `<h1>`s and no `<h2>` at all. Now h1 → h2 → h3 → h4. Size classes are untouched, so nothing moves visually.

## Two behaviour changes

- **The scoreboard renders `0/695` server-side** instead of a hardcoded `0/999` that the client script immediately overwrote — the wrong number was visible on every load. The build-time count mirrors `updateScoreboard()` and was verified against the browser's own figure.
- **The theme toggle moved into the shared nav.** It only existed on the About page, so the nicest feature on the site sat on the page nobody visits twice. It's now on About and the guide.

## Verification

Ran the 35-check browser suite from #9 against a production build: all pass, no console errors. Confirmed the theme toggle now cycles from the guide page, the scoreboard's first paint matches the JS total, and heading counts are 1×h1 / 5×h2 / 7×h3 / 4×h4.